### PR TITLE
fix : upstream main 브랜치에만 githubAction 트리거 되도록 수정

### DIFF
--- a/.github/workflows/CICD.yaml
+++ b/.github/workflows/CICD.yaml
@@ -3,8 +3,10 @@ name: CI/CD
 on:
   push:
     branches:
-      - dev
-
+      - main
+    repositories:
+      - upstream/repository-name
+      
 jobs:
   cicd:
     runs-on: ubuntu-latest


### PR DESCRIPTION
fix : upstream main 브랜치에만 githubAction 트리거 되도록 수정